### PR TITLE
Security patch

### DIFF
--- a/manifests/osgi/config/file.pp
+++ b/manifests/osgi/config/file.pp
@@ -28,7 +28,7 @@ define aem::osgi::config::file(
     ensure  => $ensure,
     group   => $group,
     content => epp("${module_name}/osgi.config.epp", $file_props),
-    mode    => '0664',
+    mode    => '0660',
     owner   => $user,
   }
 


### PR DESCRIPTION
OSGi configs can contain sensitive information like passwords (in plain text). Removed the world-readable bit.