### PR TITLE
Disable vanity load on startup

### DIFF
--- a/manifests/dispatcher/farm.pp
+++ b/manifests/dispatcher/farm.pp
@@ -29,7 +29,7 @@ define aem::dispatcher::farm(
   Variant[Optional[Array[Hash]], Optional[Hash]]  $statistics          = undef,
   Variant[Optional[Array[String]], Optional[String]] $sticky_connections  = undef,
   Optional[Integer] $unavailable_penalty = undef,
-  Optional[Hash[String, Variant[String, Integer]]] $vanity_urls         = undef,
+  Optional[Hash[String, Variant[String, Integer, Boolean]]] $vanity_urls  = undef,
   Variant[Optional[Array[String]], Optional[String]] $virtualhosts        = $::aem::dispatcher::params::virtualhosts
 ) {
 
@@ -124,7 +124,7 @@ define aem::dispatcher::farm(
       }
     }
   }
-  
+
   if $statistics {
     if $statistics =~ Array[Hash] {
       $_statistics = $statistics

--- a/manifests/dispatcher/farm.pp
+++ b/manifests/dispatcher/farm.pp
@@ -29,7 +29,7 @@ define aem::dispatcher::farm(
   Variant[Optional[Array[Hash]], Optional[Hash]]  $statistics          = undef,
   Variant[Optional[Array[String]], Optional[String]] $sticky_connections  = undef,
   Optional[Integer] $unavailable_penalty = undef,
-  Optional[Hash[String, Variant[String, Integer, Boolean]]] $vanity_urls  = undef,
+  Optional[Hash[String, Variant[String, Integer]]] $vanity_urls         = undef,
   Variant[Optional[Array[String]], Optional[String]] $virtualhosts        = $::aem::dispatcher::params::virtualhosts
 ) {
 

--- a/templates/dispatcher/dispatcher.any.erb
+++ b/templates/dispatcher/dispatcher.any.erb
@@ -89,6 +89,7 @@
   /vanity_urls {
     /url "/libs/granite/dispatcher/content/vanityUrls.html"
     /file "<%= @vanity_urls['file'] -%>"
+    /loadOnStartup 0
     /delay "<%= @vanity_urls['delay'] -%>"
   }
   <%- end -%>

--- a/templates/dispatcher/dispatcher.any.erb
+++ b/templates/dispatcher/dispatcher.any.erb
@@ -33,7 +33,7 @@
 
   /renders {
   <%- @_renders.each_with_index do |renderer, idx| -%>
-    /renderer<%= idx -%> { 
+    /renderer<%= idx -%> {
       /hostname "<%= renderer['hostname'] -%>"
       /port "<%= renderer['port'] -%>"
       <%- if renderer['timeout'] -%>
@@ -89,7 +89,9 @@
   /vanity_urls {
     /url "/libs/granite/dispatcher/content/vanityUrls.html"
     /file "<%= @vanity_urls['file'] -%>"
+    <%- if @vanity_urls.key?('load_on_startup') && ! @vanity_urls['load_on_startup'] -%>
     /loadOnStartup 0
+    <%- end -%>
     /delay "<%= @vanity_urls['delay'] -%>"
   }
   <%- end -%>

--- a/templates/dispatcher/dispatcher.any.erb
+++ b/templates/dispatcher/dispatcher.any.erb
@@ -33,7 +33,7 @@
 
   /renders {
   <%- @_renders.each_with_index do |renderer, idx| -%>
-    /renderer<%= idx -%> {
+    /renderer<%= idx -%> { 
       /hostname "<%= renderer['hostname'] -%>"
       /port "<%= renderer['port'] -%>"
       <%- if renderer['timeout'] -%>
@@ -89,8 +89,8 @@
   /vanity_urls {
     /url "/libs/granite/dispatcher/content/vanityUrls.html"
     /file "<%= @vanity_urls['file'] -%>"
-    <%- if @vanity_urls.key?('load_on_startup') && ! @vanity_urls['load_on_startup'] -%>
-    /loadOnStartup 0
+    <%- if @vanity_urls.key?('load_on_startup') -%>
+    /loadOnStartup <%= @vanity_urls['load_on_startup'] -%>
     <%- end -%>
     /delay "<%= @vanity_urls['delay'] -%>"
   }


### PR DESCRIPTION
This option will prevent filling up our tmp folder with vanity url files when upgrading dispatcher to 4.3.6.

This is safe to merge already, as `undef` will result in a NOP.